### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@eth-optimism/solc": "0.5.16-alpha.0",
     "@eth-optimism/ovm-truffle-provider-wrapper": "^0.0.1-alpha.27",
     "rimraf": "^2.6.3",
+    "scrypt": "^6.0.3",
     "truffle": "^5.1.12",
     "truffle-hdwallet-provider": "^1.0.17"
   },


### PR DESCRIPTION
This should fix the `yarn all:ovm` outcome:

```
(node:21011) UnhandledPromiseRejectionWarning: Error: Cannot find module 'scrypt'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:613:15)
    at Function.Module._load (internal/modules/cjs/loader.js:539:25)
    at Module.require (internal/modules/cjs/loader.js:667:17)
    at require (internal/modules/cjs/helpers.js:20:18)
```